### PR TITLE
Ping Gearman Client before adding workload

### DIFF
--- a/Service/Gearman.php
+++ b/Service/Gearman.php
@@ -66,6 +66,11 @@ class Gearman
         $workload = $job->getWorkload();
         $workload = serialize($workload);
 
+        //GEARMAN_COULD_NOT_CONNECT: 26
+        if (@$this->gearmanClient->ping($workload) !== 26) {
+            return new GearmanJobStatus($job, null, $this->gearmanClient->returnCode());
+        }
+
         if ($background) {
             if (GearmanJobInterface::PRIORITY_LOW == $priority) {
                 $jobHandle = $this->gearmanClient->doLowBackground($functionToCall, $workload, $job->getUnique());


### PR DESCRIPTION
When Gearman servers are not available, PHP's Gearman library raise a warning instead of an error. When this happens, ->addJob fails silently.

This PR changes the returned status code from GEARMAN_SUCCESS to GEARMAN_COULD_NOT_CONNECT when above scenario occurs.